### PR TITLE
load tf text classification model correctly in new transformers

### DIFF
--- a/validator/main.py
+++ b/validator/main.py
@@ -48,6 +48,9 @@ class BiasCheck(Validator):
             'text-classification',
             model="d4data/bias-detection-model",
             tokenizer="d4data/bias-detection-model",
+            framework="tf",
+            from_tf=True,
+            torch_dtype=None
         )
 
     def validate(

--- a/validator/post-install.py
+++ b/validator/post-install.py
@@ -4,5 +4,8 @@ _ = pipeline(
     'text-classification',
     model="d4data/bias-detection-model",
     tokenizer="d4data/bias-detection-model",
+    framework="tf",
+    from_tf=True,
+    torch_dtype=None
 )
 print("post-install complete!")


### PR DESCRIPTION
For new transformers, I got error
```bash
while loading with TFAutoModelForSequenceClassification, an error is thrown:
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/transformers/pipelines/base.py", line 310, in infer_framework_load_model
    model = model_class.from_pretrained(model, **fp32_kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/transformers/models/auto/auto_factory.py", line 600, in from_pretrained
    return model_class.from_pretrained(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/transformers/modeling_tf_utils.py", line 2935, in from_pretrained
    model = cls(config, *model_args, **model_kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/transformers/models/distilbert/modeling_tf_distilbert.py", line 768, in __init__
    super().__init__(config, *inputs, **kwargs)
  File "/usr/local/lib/python3.11/site-packages/transformers/modeling_tf_utils.py", line 1190, in __init__
    super().__init__(*inputs, **kwargs)
  File "/usr/local/lib/python3.11/site-packages/tensorflow/python/trackable/base.py", line 204, in _method_wrapper
    result = method(self, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/tf_keras/src/utils/traceback_utils.py", line 70, in error_handler
    raise e.with_traceback(filtered_tb) from None
  File "/usr/local/lib/python3.11/site-packages/tf_keras/src/utils/generic_utils.py", line 513, in validate_kwargs
    raise TypeError(error_message, kwarg)
TypeError: ('Keyword argument not understood:', 'torch_dtype')

```

I fixed the calling of pipeline to solve the errors.